### PR TITLE
Bugfix - Remove re package installation step from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ Hayagriva requires the following Python libraries:
 * requests
 * bs4
 * ipaddress
-* re
 
 You can install these libraries using pip:
 
 ```bash
-pip install requests bs4 ipaddress re
+pip install requests bs4 ipaddress
 ```
 # Usage
 


### PR DESCRIPTION
## Pull Request

### Description

Bugfix - No need to mention installing re package since it is a python standard library

### Changes Made

- Update readme.md file to remove re package installation

### Related Issue

- Fixes #3 

